### PR TITLE
Adoption interest notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'activestorage', '>= 5.2.1.1'
 
 gem 'route_translator'
 gem 'i18n'
+gem 'sidekiq'
 
 group :development, :test do
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,8 @@ GEM
     public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
+    rack-protection (2.0.7)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -266,6 +268,7 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
+    redis (4.1.3)
     regexp_parser (1.6.0)
     responders (3.0.0)
       actionpack (>= 5.0)
@@ -327,6 +330,11 @@ GEM
     sentry-raven (2.12.2)
       faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
+    sidekiq (6.0.3)
+      connection_pool (>= 2.2.2)
+      rack (>= 2.0.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -410,6 +418,7 @@ DEPENDENCIES
   rubocop (~> 0.62.0)
   sass-rails (~> 5.0)
   sentry-raven
+  sidekiq
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/ngo_area.scss
+++ b/app/assets/stylesheets/ngo_area.scss
@@ -1,2 +1,13 @@
 @import 'font-awesome';
 @import 'bootstrap_sb_admin_base_v2';
+
+.notification-badger {
+  background-color: #e74a3b;
+  width: 10px;
+  height: 10px;
+  border-radius: 100%;
+  display: inline-block;
+  position: absolute;
+  right: 1rem;
+  margin-top: 0.75rem;
+}

--- a/app/controllers/ngo_area/adoption_interests_controller.rb
+++ b/app/controllers/ngo_area/adoption_interests_controller.rb
@@ -2,4 +2,10 @@ class NgoArea::AdoptionInterestsController < NgoAreaController
   def index
     @adoption_interests = AdoptionInterest.by_ngo_user(current_user)
   end
+
+  def mark_notification_as_read
+    AdoptionInterestNotification.find(params[:notification_id]).update_attributes!(read: true)
+
+    redirect_to ngo_area_adoption_interests_path
+  end
 end

--- a/app/helpers/ngo_area/ngo_area_helper.rb
+++ b/app/helpers/ngo_area/ngo_area_helper.rb
@@ -1,5 +1,8 @@
 module NgoArea::NgoAreaHelper
   def adoption_interest_notification(user)
-    AdoptionInterestNotification.where(user: user, read: false)
+    AdoptionInterestNotification
+      .joins(adoption_interest: [:user, :pet])
+      .includes(adoption_interest: [:user, :pet])
+      .where(user: user, read: false)
   end
 end

--- a/app/helpers/ngo_area/ngo_area_helper.rb
+++ b/app/helpers/ngo_area/ngo_area_helper.rb
@@ -1,0 +1,5 @@
+module NgoArea::NgoAreaHelper
+  def adoption_interest_notification(user)
+    AdoptionInterestNotification.where(user: user, read: false)
+  end
+end

--- a/app/jobs/notify_adoption_interest.rb
+++ b/app/jobs/notify_adoption_interest.rb
@@ -1,0 +1,9 @@
+class NotifyAdoptionInterest < ApplicationJob
+  queue_as :default
+
+  def perform(adoption_interest)
+    adoption_interest.pet.ngo.users.each do |user|
+      AdoptionInterestNotification.create(user: user, adoption_interest: adoption_interest)
+    end
+  end
+end

--- a/app/models/adoption_interest.rb
+++ b/app/models/adoption_interest.rb
@@ -9,4 +9,12 @@ class AdoptionInterest < ApplicationRecord
       self.joins(:pet).where(pets: { ngo: user.ngos })
     end
   end
+
+  after_create :notify_user
+
+  private
+
+  def notify_user
+    NotifyAdoptionInterest.perform_later(user)
+  end
 end

--- a/app/models/adoption_interest.rb
+++ b/app/models/adoption_interest.rb
@@ -15,6 +15,6 @@ class AdoptionInterest < ApplicationRecord
   private
 
   def notify_user
-    NotifyAdoptionInterest.perform_later(user)
+    NotifyAdoptionInterest.perform_later(self)
   end
 end

--- a/app/models/adoption_interest_notification.rb
+++ b/app/models/adoption_interest_notification.rb
@@ -1,0 +1,4 @@
+class AdoptionInterestNotification < ApplicationRecord
+  belongs_to :user
+  belongs_to :adoption_interest
+end

--- a/app/views/layouts/ngo_area.html.erb
+++ b/app/views/layouts/ngo_area.html.erb
@@ -35,12 +35,16 @@
     <ul class="nav navbar-top-links navbar-right">
       <li class="dropdown">
         <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-          <i class="fa fa-bell fa-fw"></i> <i class="fa fa-caret-down"></i>
+          <i class="fa fa-bell fa-fw">
+            <% if adoption_interest_notification(current_user).length > 0 %>
+              <span class="notification-badger" />
+            <% end %>
+          </i>
         </a>
         <ul class="dropdown-menu dropdown-alerts">
           <% adoption_interest_notification(current_user).each do |notification| %>
             <li>
-              <a href="<%= ngo_area_adoption_interests_path %>">
+              <a href="<%= ngo_area_mark_notification_as_read_path(notification_id: notification) %>">
                 <div>
                   <strong><%= notification.adoption_interest.user.name || notification.adoption_interest.user.email %></strong> acabou de registrar interesse no pet <strong><%= notification.adoption_interest.pet.name %></strong>
                   <span class="pull-right text-muted small"><%= time_ago_in_words(notification.created_at) %></span>
@@ -50,9 +54,7 @@
           <% end %>
           <li>
             <a class="text-center" href="<%= ngo_area_adoption_interests_path %>">
-              <!-- TODO: clean notifications -->
-              <strong>Veja mais</strong>
-              <i class="fa fa-angle-right"></i>
+              <strong>Ir para interessados em adoção</strong>
             </a>
           </li>
         </ul>

--- a/app/views/layouts/ngo_area.html.erb
+++ b/app/views/layouts/ngo_area.html.erb
@@ -42,7 +42,7 @@
             <li>
               <a href="<%= ngo_area_adoption_interests_path %>">
                 <div>
-                  <strong><%= notification.adoption_interest.user.name %></strong> acabou de registrar interesse no pet <strong><%= notification.adoption_interest.pet.name %></strong>
+                  <strong><%= notification.adoption_interest.user.name || notification.adoption_interest.user.email %></strong> acabou de registrar interesse no pet <strong><%= notification.adoption_interest.pet.name %></strong>
                   <span class="pull-right text-muted small"><%= time_ago_in_words(notification.created_at) %></span>
                 </div>
               </a>

--- a/app/views/layouts/ngo_area.html.erb
+++ b/app/views/layouts/ngo_area.html.erb
@@ -38,27 +38,18 @@
           <i class="fa fa-bell fa-fw"></i> <i class="fa fa-caret-down"></i>
         </a>
         <ul class="dropdown-menu dropdown-alerts">
+          <% adoption_interest_notification(current_user).each do |notification| %>
+            <li>
+              <a href="<%= ngo_area_adoption_interests_path %>">
+                <div>
+                  <strong><%= notification.adoption_interest.user.name %></strong> acabou de registrar interesse no pet <strong><%= notification.adoption_interest.pet.name %></strong>
+                  <span class="pull-right text-muted small"><%= time_ago_in_words(notification.created_at) %></span>
+                </div>
+              </a>
+            </li>
+          <% end %>
           <li>
-            <!-- TODO: add adoption request link -->
-            <a href="#">
-              <div>
-                <strong>Tiago Giusti</strong> acabou de registrar interesse no pet <strong>Tobby</strong>
-                <!-- TODO: add adoption request time -->
-                <span class="pull-right text-muted small">4 minutes ago</span>
-              </div>
-            </a>
-          </li>
-          <li>
-            <a href="#">
-              <div>
-                <strong>Caroline Salib</strong> acabou de registrar interesse no pet <strong>Robson</strong>
-                <span class="pull-right text-muted small">4 minutes ago</span>
-              </div>
-            </a>
-          </li>
-          <li>
-            <a class="text-center" href="#">
-              <!-- TODO: add adoption request link -->
+            <a class="text-center" href="<%= ngo_area_adoption_interests_path %>">
               <!-- TODO: clean notifications -->
               <strong>Veja mais</strong>
               <i class="fa fa-angle-right"></i>

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,7 @@ module Uberdo3setor
     config.time_zone = 'America/Sao_Paulo'
 
     config.filter_parameters << :password
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,12 @@
 Rails.application.routes.draw do
+  require 'sidekiq/web'
+
+  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+    username == ENV['SIDEKIQ_USER'] && password == ENV['SIDEKIQ_PASSWORD']
+  end if Rails.env.production?
+
+  mount Sidekiq::Web => '/sidekiq'
+
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
   root 'home#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
       resources :pets, only: %i[index new create edit update destroy]
       resources :users, only: %i[index new create edit update destroy]
       resources :adoption_interests, only: %i[index]
+
+      get 'mark_notification_as_read/:notification_id', to: 'adoption_interests#mark_notification_as_read', as: 'mark_notification_as_read'
     end
   end
 

--- a/db/migrate/20191203141118_create_adoption_interest_notifications.rb
+++ b/db/migrate/20191203141118_create_adoption_interest_notifications.rb
@@ -1,0 +1,11 @@
+class CreateAdoptionInterestNotifications < ActiveRecord::Migration[5.2]
+  def change
+    create_table :adoption_interest_notifications do |t|
+      t.references :user, foreign_key: true
+      t.references :adoption_interest, foreign_key: true
+      t.boolean :read, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_30_134827) do
+ActiveRecord::Schema.define(version: 2019_12_03_141118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,16 @@ ActiveRecord::Schema.define(version: 2019_10_30_134827) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "adoption_interest_notifications", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "adoption_interest_id"
+    t.boolean "read", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["adoption_interest_id"], name: "index_adoption_interest_notifications_on_adoption_interest_id"
+    t.index ["user_id"], name: "index_adoption_interest_notifications_on_user_id"
   end
 
   create_table "adoption_interests", force: :cascade do |t|
@@ -131,6 +141,8 @@ ActiveRecord::Schema.define(version: 2019_10_30_134827) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "adoption_interest_notifications", "adoption_interests"
+  add_foreign_key "adoption_interest_notifications", "users"
   add_foreign_key "bank_accounts", "ngos"
   add_foreign_key "pets", "ngos"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,18 +44,21 @@ Ngo.last.image.attach(io: File.open("public/images/ngo/amigobicho.png"), filenam
 puts 'Creating Users'
 
 User.create!(
+  name: 'Usuário admin',
   email: 'admin@boacausa.com',
   password: '123456789',
   group: :admin,
 )
 
 ngo_user = User.create!(
+  name: 'Usuário da ONG',
   email: 'ngo@boacausa.com',
   password: '123456789',
   group: :ngo
 )
 
 User.create!(
+  name: 'Usuário normal',
   email: 'user@boacausa.com',
   password: '123456789',
 )

--- a/spec/controllers/ngo_area/adoption_interests_controller_spec.rb
+++ b/spec/controllers/ngo_area/adoption_interests_controller_spec.rb
@@ -12,4 +12,20 @@ describe NgoArea::AdoptionInterestsController do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe 'GET mark_notification_as_read' do
+    context 'when find the notification' do
+      let(:notification) { FactoryBot.create(:adoption_interest_notification) }
+
+      subject { get :mark_notification_as_read, params: { notification_id: notification.id } }
+
+      it 'redirects to adoption interest path' do
+        expect(subject).to redirect_to(action: :index)
+      end
+
+      it 'change notification to read' do
+        expect { subject }.to change { notification.reload.read }.from(false).to(true)
+      end
+    end
+  end
 end

--- a/spec/factories/adoption_interest_notifications.rb
+++ b/spec/factories/adoption_interest_notifications.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :adoption_interest_notification do
-    user { nil }
-    adoption_interest { nil }
+    user
+    adoption_interest
     read { false }
   end
 end

--- a/spec/factories/adoption_interest_notifications.rb
+++ b/spec/factories/adoption_interest_notifications.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :adoption_interest_notification do
+    user { nil }
+    adoption_interest { nil }
+    read { false }
+  end
+end

--- a/spec/factories/adoption_interests.rb
+++ b/spec/factories/adoption_interests.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :adoption_interest do
-    user_id { 1 }
-    pet_id { 1 }
+    user
+    pet
   end
 end

--- a/spec/jobs/notify_adoption_interest_spec.rb
+++ b/spec/jobs/notify_adoption_interest_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe NotifyAdoptionInterest do
+  describe '#perform' do
+    before do
+      allow_any_instance_of(AdoptionInterest).to receive(:notify_user).and_return(nil)
+    end
+
+    it 'creates an adoption interest notification' do
+      user1 = create(:user, :ngo_privileges)
+
+      ngo1 = create(:ngo)
+      ngo2 = create(:ngo)
+
+      ngo_user1 = create(:user, :ngo_privileges)
+      ngo_user2 = create(:user, :ngo_privileges)
+      ngo_user3 = create(:user, :admin_privileges)
+      ngo_user4 = create(:user, :admin_privileges)
+
+      ngo_user1.ngos << ngo1
+      ngo_user2.ngos << ngo1
+      ngo_user3.ngos << ngo1
+      ngo_user4.ngos << ngo2
+
+      pet1 = create(:pet, ngo: ngo1)
+      _pet2 = create(:pet, ngo: ngo2)
+
+      adoption_interest = create(:adoption_interest, user: user1, pet: pet1)
+
+      expect(AdoptionInterestNotification.where(user: [ngo_user1, ngo_user2, ngo_user3], adoption_interest: adoption_interest).count).to eq(0)
+      expect { described_class.perform_now(adoption_interest) }.to change { AdoptionInterestNotification.count }.by(3)
+      expect(AdoptionInterestNotification.where(user: ngo_user1, adoption_interest: adoption_interest).count).to eq(1)
+      expect(AdoptionInterestNotification.where(user: ngo_user2, adoption_interest: adoption_interest).count).to eq(1)
+      expect(AdoptionInterestNotification.where(user: ngo_user3, adoption_interest: adoption_interest).count).to eq(1)
+    end
+  end
+end

--- a/spec/models/adoption_interest_notification_spec.rb
+++ b/spec/models/adoption_interest_notification_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AdoptionInterestNotification, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/adoption_interest_spec.rb
+++ b/spec/models/adoption_interest_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe AdoptionInterest, type: :model do
   describe '#notify_user' do
     it 'enqueues a job' do
-      FactoryBot.create(:adoption_interest)
-      expect(NotifyAdoptionInterest).to have_been_enqueued.exactly(:once)
+      adoption_interest = FactoryBot.create(:adoption_interest)
+      expect(NotifyAdoptionInterest).to have_been_enqueued.with(adoption_interest).exactly(:once)
     end
   end
 

--- a/spec/models/adoption_interest_spec.rb
+++ b/spec/models/adoption_interest_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 describe AdoptionInterest, type: :model do
+  describe '#notify_user' do
+    it 'enqueues a job' do
+      FactoryBot.create(:adoption_interest)
+      expect(NotifyAdoptionInterest).to have_been_enqueued.exactly(:once)
+    end
+  end
+
   describe '.by_ngo_user' do
     let(:ngo_1) { FactoryBot.create(:ngo) }
     let(:ngo_2) { FactoryBot.create(:ngo) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,8 @@ SimpleCov.start
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+ActiveJob::Base.queue_adapter = :test
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
Ao clicar no interesse na notificação o usuário vai ser redirecionado para a página de interesse em adoção e a notificação vai ser marcada como "lida", o que faz com que esta não apareça mais na lista.

Quando tem notificação de interesse em adoção:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/5773360/71181965-69fb2f80-2232-11ea-8c87-dfe3e0eeeb1a.png">

Quando não tem notificação de interesse em adoção:
<img width="352" alt="image" src="https://user-images.githubusercontent.com/5773360/71181851-37e9cd80-2232-11ea-9ff4-e5a7574c61e7.png">

#113